### PR TITLE
Changed focus color to be primary using outline

### DIFF
--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -15,7 +15,20 @@ export interface TextInputProps
   rightIcon?: IconType;
 }
 
-const defaultTextInput = tw.input`px-4 py-2 block w-full truncate border rounded-md border-gray-300 focus:ring-2 focus:ring-primary sm:text-sm dark:border-gray-700 dark:focus:ring-2 dark:focus:ring-primary dark:bg-gray-950`;
+const defaultTextInput = tw.input`
+  px-4 py-2
+  block
+  w-full
+  truncate
+  border
+  rounded-md
+  border-gray-300
+  focus:outline-blue
+  sm:text-sm
+  dark:border-gray-700
+  dark:focus:outline-blue
+  dark:bg-gray-950
+`;
 
 function getStyledInput(props: TextInputProps) {
   let styleInput = defaultTextInput;
@@ -27,9 +40,15 @@ function getStyledInput(props: TextInputProps) {
     styleInput = tw(styleInput)`pr-10`;
   }
   if (!!props.hasError) {
-    styleInput = tw(
-      styleInput
-    )`pr-10 text-red-800 placeholder-red-300 border-red-100 focus:outline-none focus:border-red-300 dark:bg-gray-950 dark:border-red-300 dark:text-red-300 dark:focus:border-red-600`;
+    styleInput = tw(styleInput)`pr-10 
+    text-red-800
+    placeholder-red-300
+    border-red-100
+    focus:outline-red-300
+    dark:bg-gray-950
+    dark:border-red-300
+    dark:text-red-300
+    dark:focus:outline-red-600`;
   }
   return styleInput;
 }
@@ -51,7 +70,7 @@ export function TextInputComponent(props: TextInputProps) {
       {React.Children.map(children, (child) => {
         if (child.type === LabelComponent) return child;
       })}
-      <div tw="mt-1 relative rounded-md shadow-sm overflow-hidden">
+      <div tw="mt-1 relative rounded-md shadow-sm">
         {!!leftIcon && (
           <div tw="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <div tw="h-5 w-5 text-gray-300" aria-hidden="true">

--- a/src/components/inputs/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/inputs/__snapshots__/TextInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput Component should render default text input with no children 1`] = `
 <input
-  class="TextInput__defaultTextInput-sc-qqk5wt-0 TextInput__styleInput-sc-qqk5wt-1 TextInput__styleInput-sc-qqk5wt-2 TextInput__styleInput-sc-qqk5wt-3 jEzmMj iqqeeC gzvCKe eHZqOs"
+  class="TextInput__defaultTextInput-sc-qqk5wt-0 TextInput__styleInput-sc-qqk5wt-1 TextInput__styleInput-sc-qqk5wt-2 TextInput__styleInput-sc-qqk5wt-3 bVSAZY iqqeeC gzvCKe drIIHv"
   data-testid="text-input-component"
   id="TextInputId"
   name="TextInputName"
@@ -13,7 +13,7 @@ exports[`TextInput Component should render default text input with no children 1
 
 exports[`TextInput Component should render text input with children components 1`] = `
 <input
-  class="TextInput__defaultTextInput-sc-qqk5wt-0 TextInput__styleInput-sc-qqk5wt-1 TextInput__styleInput-sc-qqk5wt-2 TextInput__styleInput-sc-qqk5wt-3 jEzmMj iqqeeC gzvCKe eHZqOs"
+  class="TextInput__defaultTextInput-sc-qqk5wt-0 TextInput__styleInput-sc-qqk5wt-1 TextInput__styleInput-sc-qqk5wt-2 TextInput__styleInput-sc-qqk5wt-3 bVSAZY iqqeeC gzvCKe drIIHv"
   data-testid="text-input-component"
   id="TextInputId"
   name="TextInputName"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -108,6 +108,15 @@ module.exports = {
         975: "#080B1A",
       },
     },
+    extend: {
+      outline: {
+        blue: "2px solid #3366FF",
+        red: {
+          300: "2px solid #ff7461",
+          600: "2px solid #db202a",
+        },
+      },
+    },
   },
   variants: {
     extend: {


### PR DESCRIPTION
 Added extend.outling.colors in order to define shades for the outline. These are not provided by default in Tailwind.